### PR TITLE
fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@
   robust and usually does not hang / crash if there are small angles
   in the input geometry.
 * In cases where Triangle previously hung (displaying an error message)
-  when an error occured, the program now terminates and indicates that
-  an error has occured.  This is especially useful for Matlab/Octave
+  when an error occurred, the program now terminates and indicates that
+  an error has occurred.  This is especially useful for Matlab/Octave
   scripts, which now get passed the error indication rather than having
   the script hang on the meshing error. 
 * Fixed a number of additional instances of focus-stealing during script
@@ -209,7 +209,7 @@
 * Changed .dxf import so that objects assigned layers are imported as
   grouped being in the same group.
 * Added new "Improvised Asymptotic Boundary Condition" button and mi_makeABC
-  and friends Lua funtions as an alternate way of solving unbounded
+  and friends Lua functions as an alternate way of solving unbounded
   problems.
 
 11Apr2012:

--- a/ResizableLib/ResizableLayout.cpp
+++ b/ResizableLib/ResizableLayout.cpp
@@ -253,7 +253,7 @@ void CResizableLayout::EraseBackground(CDC* pDC)
   HBRUSH hBrush = NULL;
 
   // is this a dialog box?
-  // (using class atom is quickier than using the class name)
+  // (using class atom is quicker than using the class name)
   ATOM atomWndClass = (ATOM)::GetClassLong(hWnd, GCW_ATOM);
   if (atomWndClass == (ATOM)0x8002) {
     // send a message to the dialog box

--- a/ResizableLib/ResizableMsgSupport.h
+++ b/ResizableLib/ResizableMsgSupport.h
@@ -22,7 +22,7 @@
 #endif // _MSC_VER > 1000
 
 typedef struct tagRESIZEPROPERTIES {
-  // wether to ask for resizing properties every time
+  // whether to ask for resizing properties every time
   BOOL bAskClipping;
   BOOL bAskRefresh;
   // otherwise, use the cached properties

--- a/ResizableLib/ResizableSheet.cpp
+++ b/ResizableLib/ResizableSheet.cpp
@@ -301,7 +301,7 @@ void CResizableSheet::EnableSaveRestore(LPCTSTR pszSection, BOOL bRectOnly, BOOL
   LoadPage();
 }
 
-// private memebers
+// private members
 
 // used to save/restore active page
 // either in the registry or a private .INI file

--- a/ResizableLib/ResizableSheetEx.cpp
+++ b/ResizableLib/ResizableSheetEx.cpp
@@ -329,7 +329,7 @@ void CResizableSheetEx::EnableSaveRestore(LPCTSTR pszSection, BOOL bRectOnly, BO
   LoadPage();
 }
 
-// private memebers
+// private members
 
 // used to save/restore active page
 // either in the registry or a private .INI file

--- a/femm/CVIEWDOC.CPP
+++ b/femm/CVIEWDOC.CPP
@@ -1417,7 +1417,7 @@ void CcviewDoc::GetLineValues(CXYPlot& p, int PlotType, int NumPlotPoints)
 	m_XYPlotType.AddString("|Jc|   (Magnitude of conduction current density)");
 	m_XYPlotType.AddString("Jc . n (Normal conduction current density)");
 	m_XYPlotType.AddString("Jc . t (Tangential conduction current density)");
-	m_XYPlotType.AddString("|Jd|   (Magnitude of displacment current density)");
+	m_XYPlotType.AddString("|Jd|   (Magnitude of displacement current density)");
 	m_XYPlotType.AddString("Jd . n (Normal displacement current density)");
 	m_XYPlotType.AddString("Jd . t (Tangential displacement current density)");
 	*/

--- a/femm/FemmviewDoc.cpp
+++ b/femm/FemmviewDoc.cpp
@@ -1904,7 +1904,7 @@ BOOL CFemmviewDoc::GetPointValues(double x, double y, int k, CPointVals& u)
         u.mu2 = muinc;
         u.mu12 = 0;
       } else if (bIncremental == 1) {
-        // For "incremental" problem, permeability is linearized about the prevous soluiton.
+        // For "incremental" problem, permeability is linearized about the previous soluiton.
         u.mu1 = (B1p * B1p * muinc + B2p * B2p * murel) / (B * B);
         u.mu12 = (B1p * B2p * (muinc - murel)) / (B * B);
         u.mu2 = (B2p * B2p * muinc + B1p * B1p * murel) / (B * B);
@@ -4598,7 +4598,7 @@ CComplex CFemmviewDoc::GetFluxLinkage(int circnum)
 
         // if there is at least one nonzero conductivity block, we can use
         // the GetParallelLinkage routine, which is more or less driving
-        // all the blocks with a ficticious voltage gradient.
+        // all the blocks with a fictitious voltage gradient.
         if (flag)
           FluxLinkage = GetParallelLinkage(i);
         // otherwise, treat the "punt" case, where every part of the

--- a/femm/MainFrm.cpp
+++ b/femm/MainFrm.cpp
@@ -548,7 +548,7 @@ void CMainFrame::DockControlBarLeftOf(CToolBar* Bar, CToolBar* LeftOf)
   n = (dw & CBRS_ALIGN_RIGHT && n == 0) ? AFX_IDW_DOCKBAR_RIGHT : n;
 
   // When we take the default parameters on rect, DockControlBar will dock
-  // each Toolbar on a seperate line. By calculating a rectangle, we
+  // each Toolbar on a separate line. By calculating a rectangle, we
   // are simulating a Toolbar being dragged to that location and docked.
   DockControlBar(Bar, n, &rect);
 }

--- a/femm/ResizableMsgSupport.h
+++ b/femm/ResizableMsgSupport.h
@@ -22,7 +22,7 @@
 #endif // _MSC_VER > 1000
 
 typedef struct tagRESIZEPROPERTIES {
-  // wether to ask for resizing properties every time
+  // whether to ask for resizing properties every time
   BOOL bAskClipping;
   BOOL bAskRefresh;
   // otherwise, use the cached properties

--- a/femm/StdAfx.h
+++ b/femm/StdAfx.h
@@ -51,7 +51,7 @@
 // uncomment the following if you want to compile with MathLink support.
 // #define MATHLINK
 
-// commend the following line if you don't want a tabbed MDI interface.
+// comment the following line if you don't want a tabbed MDI interface.
 #define MDITAB
 
 #include "complex.h"

--- a/femm/XYPlotDlg.cpp
+++ b/femm/XYPlotDlg.cpp
@@ -81,7 +81,7 @@ BOOL CXYPlotDlg::OnInitDialog()
     m_XYPlotType.AddString("H . n      (Normal field intensity)");
     m_XYPlotType.AddString("H . t      (Tangential field intensity)");
     m_XYPlotType.AddString("J_eddy     (Eddy current density)");
-    m_XYPlotType.AddString("Js+J_eddy  (Source+eddy curent density)");
+    m_XYPlotType.AddString("Js+J_eddy  (Source+eddy current density)");
     m_XYPlotType.SetCurSel(1);
   }
 

--- a/femm/cd_nosebl.cpp
+++ b/femm/cd_nosebl.cpp
@@ -115,7 +115,7 @@ CMaterialProp::CMaterialProp()
   BlockName = "New Material";
   ox = oy = 0.; // electrical conductivity, MS/m
   ex = ey = 1.; // electrical permittivity, relative
-  ltx = lty = 0; // loss tangent of electrial permittivity
+  ltx = lty = 0; // loss tangent of electrical permittivity
 }
 
 CMaterialProp::~CMaterialProp()

--- a/femm/cv_XYPlotDlg.cpp
+++ b/femm/cv_XYPlotDlg.cpp
@@ -72,7 +72,7 @@ BOOL cvCXYPlotDlg::OnInitDialog()
   m_XYPlotType.AddString("|Jc|   (Magnitude of conduction current density)");
   m_XYPlotType.AddString("Jc . n (Normal conduction current density)");
   m_XYPlotType.AddString("Jc . t (Tangential conduction current density)");
-  m_XYPlotType.AddString("|Jd|   (Magnitude of displacment current density)");
+  m_XYPlotType.AddString("|Jd|   (Magnitude of displacement current density)");
   m_XYPlotType.AddString("Jd . n (Normal displacement current density)");
   m_XYPlotType.AddString("Jd . t (Tangential displacement current density)");
   m_XYPlotType.SetCurSel(0);

--- a/femm/femm.cpp
+++ b/femm/femm.cpp
@@ -757,8 +757,8 @@ int CFemmApp::lua_ERROR(lua_State* L)
   errmsg.Format("%s", lua_tostring(L, 1));
   theApp.LuaErrmsg = errmsg;
 
-  // Somthing went wrong in lua execution
-  // Windows dosn't have stdout so lets afxmessagebox it
+  // Something went wrong in lua execution
+  // Windows doesn't have stdout so lets afxmessagebox it
   if (theApp.bFileLink) {
     FILE* fp;
     fp = fopen(theApp.OFile, "wt");

--- a/femm/femm.rc
+++ b/femm/femm.rc
@@ -456,7 +456,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizonal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -655,7 +655,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizonal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -740,7 +740,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizonal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -901,7 +901,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizonal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -986,7 +986,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizonal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -1099,7 +1099,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizonal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -1184,7 +1184,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizonal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -3114,7 +3114,7 @@ BEGIN
     EDITTEXT        IDC_ABCR,78,30,66,14,ES_AUTOHSCROLL
     EDITTEXT        IDC_ABCX,78,48,66,14,ES_AUTOHSCROLL
     EDITTEXT        IDC_ABCY,78,66,66,14,ES_AUTOHSCROLL
-    LTEXT           "Horizonal Center",IDC_STATIC,6,48,56,8
+    LTEXT           "Horizontal Center",IDC_STATIC,6,48,56,8
     LTEXT           "Vertical Center",IDC_STATIC,6,66,56,8
     LTEXT           "Edge Type",IDC_STATIC,6,84,56,8
     COMBOBOX        IDC_COMBO1,78,84,64,66,CBS_DROPDOWNLIST | CBS_SORT | WS_VSCROLL | WS_TABSTOP

--- a/femm/femm.rc
+++ b/femm/femm.rc
@@ -456,7 +456,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",             ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -655,7 +655,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",             ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -740,7 +740,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",             ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -901,7 +901,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",             ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -1099,7 +1099,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",             ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN
@@ -1184,7 +1184,7 @@ BEGIN
     BEGIN
         MENUITEM "Cascade",                     ID_WINDOW_CASCADE
         MENUITEM "Tile Vertical",               ID_WINDOW_TILE_VERT
-        MENUITEM "Tile Horizontal",              ID_WINDOW_TILE_HORZ
+        MENUITEM "Tile Horizontal",             ID_WINDOW_TILE_HORZ
     END
     POPUP "&Help"
     BEGIN

--- a/femm/mathlink.h
+++ b/femm/mathlink.h
@@ -165,7 +165,7 @@ unknown platform
  * number is incremented whenever a named constant or function is added,
  * removed, or its behavior is changed in a way that could break existing
  * correct* client programs.  It is expected that the interface to MathLink
- * is improved over time so that implemenations of higher numbered 
+ * is improved over time so that implementations of higher numbered 
  * interfaces are more complete or more convenient to use for writing
  * effective client programs.  In particular, a specific interface provides
  * all the useful functionality of an earlier interface.
@@ -185,7 +185,7 @@ unknown platform
  *     load the MathLink library manually.)
  * 
  * 
- * If a distributed MathLink implmentation were labeled with its revision 
+ * If a distributed MathLink implementation were labeled with its revision 
  * and interface numbers in dotted notation so that, say, ML.1.6 means the
  * sixth revision of interface one, then the following may represent the
  * distribution history of MathLink.
@@ -711,7 +711,7 @@ typedef long long_et;
 #endif
 typedef __mlapi_result__ mlapi_result;
 
-#define MLSUCCESS (1) /*bugcheck:  this stuff doesnt belong where it can be seen at MLAPI_ layer */
+#define MLSUCCESS (1) /*bugcheck:  this stuff doesn't belong where it can be seen at MLAPI_ layer */
 #define MLFAILURE (0)
 
 ML_EXTERN_C
@@ -982,7 +982,7 @@ ML_EXTERN_C
  * #define MLTK_128BIT_UNSIGNED_2sCOMPLEMENT_BIGENDIAN_INTEGER   ((unsigned char)'\257')
  * with  Range[0, 340282366920938463463374607431768211456 (*approximately 3.40282e+38*)]
  * the dynamic range is still a monotonically increasing function of the token value.
- * An implementation might choose to set the high varient bit to mainain this property
+ * An implementation might choose to set the high variant bit to maintain this property
  * and dispatch more efficiently by avoiding overflow checks
  */
 
@@ -1164,7 +1164,7 @@ ML_END_EXTERN_C
 #define MLTK_CLONGDOUBLE MLTK_BIGENDIAN_IEEE754_DOUBLE
 #elif defined(__MRC__) && __MRC__ >= 0x0300 && __MRC__ != 0x0800
 /* MrC version 1.0 defined __MRC__ to be 0x0800 presumably because of its Symantec heritage */
-/* One cannot querry value of -ldsize with old MrC or PPCC -- assume -ldsize 128 */
+/* One cannot query value of -ldsize with old MrC or PPCC -- assume -ldsize 128 */
 #if __option(ldsize128)
 #define MLTK_CLONGDOUBLE MLTK_128BIT_LONGDOUBLE
 #else
@@ -2471,7 +2471,7 @@ MLDECL(void, MLDisownLongDoubleArray, (MLINK mlp, extendedp_nt data, longp_st di
 #endif
 ML_END_EXTERN_C
 
-/*************** seeking, transfering  and synchronization ***************/
+/*************** seeking, transferring  and synchronization ***************/
 
 #ifndef _MLMARK_H
 #define _MLMARK_H

--- a/femm/writepoly.cpp
+++ b/femm/writepoly.cpp
@@ -849,7 +849,7 @@ BOOL CFemmeDoc::FunnyOnWritePoly()
   // for each arc associated with a particular Air Gap Element...
 
   // find out the total arc length and arc elements
-  // corresponding ot each lineproplist entry
+  // corresponding to each lineproplist entry
   for (i = 0; i < arclist.GetSize(); i++) {
     if (arclist[i].BoundaryMarker != "<None>") {
       for (j = 0; j < agelst.GetSize(); j++) {

--- a/fkn/cspars.cpp
+++ b/fkn/cspars.cpp
@@ -124,7 +124,7 @@ void CBigComplexLinProb::Put(CComplex v, int p, int q, int k)
       v = -conj(v); // antihermitian matrix
   }
 
-  // allocate space for auxilliary matrices if they are actually needed
+  // allocate space for auxiliary matrices if they are actually needed
   if ((k > 0) && (bNewton == FALSE)) {
     bNewton = TRUE;
 
@@ -254,12 +254,12 @@ void CBigComplexLinProb::MultA(CComplex* X, CComplex* Y, int k)
     Y[i] = 0;
 
   // force the program to give the plain matrix multiply
-  // if auxilliary matrices have not been built
+  // if auxiliary matrices have not been built
   if ((!bNewton) && (k != 0))
     k = 0;
 
   // Make the default call return the full multiply, including
-  // the auxilliary matrix multiplies, when these matrices exist
+  // the auxiliary matrix multiplies, when these matrices exist
   if ((bNewton) && (k == -1)) {
     MultA(X, Y, 0);
     MultA(X, uu, 1);

--- a/fkn/prob1big.cpp
+++ b/fkn/prob1big.cpp
@@ -818,7 +818,7 @@ BOOL CFemmeDocCore::WriteStatic2D(CBigLinProb& L)
     i = labellist[k].InCircuit;
     if (i < 0) // if block not associated with any particular circuit
     {
-      // print out some "dummy" propeties that say that
+      // print out some "dummy" properties that say that
       // there is a fixed additional current density,
       // but that that additional current density is zero.
       fprintf(fp, "1	0\n");

--- a/fkn/prob2big.cpp
+++ b/fkn/prob2big.cpp
@@ -910,7 +910,7 @@ BOOL CFemmeDocCore::WriteHarmonic2D(CBigComplexLinProb& L)
     i = labellist[k].InCircuit;
     if (i < 0) // if block not associated with any particular circuit
     {
-      // print out some "dummy" propeties that say that
+      // print out some "dummy" properties that say that
       // there is a fixed additional current density,
       // but that that additional current density is zero.
       fprintf(fp, "1	0	0\n");

--- a/fkn/tmp_prob1big.cpp
+++ b/fkn/tmp_prob1big.cpp
@@ -670,7 +670,7 @@ BOOL CFemmeDocCore::WriteStatic2D(CBigLinProb& L)
     i = labellist[k].InCircuit;
     if (i < 0) // if block not associated with any particular circuit
     {
-      // print out some "dummy" propeties that say that
+      // print out some "dummy" properties that say that
       // there is a fixed additional current density,
       // but that that additional current density is zero.
       fprintf(fp, "1	0\n");

--- a/liblua/lobject.h
+++ b/liblua/lobject.h
@@ -158,7 +158,7 @@ typedef struct Hash {
 #define ismarked(x) ((x)->mark != (x))
 
 /*
-** informations about a call (for debugging)
+** information about a call (for debugging)
 */
 typedef struct CallInfo {
   struct Closure* func; /* function being called */

--- a/manual/cflow.tex.in
+++ b/manual/cflow.tex.in
@@ -406,7 +406,7 @@ Currently, the type of line plots supported are:
 	\item {\tt |Jc|   } Magnitude of conduction current density
 	\item {\tt Jc.n } Normal conduction current density
 	\item {\tt Jc.t } Tangential conduction current density
-	\item {\tt |Jd|   } Magnitude of displacment current density
+	\item {\tt |Jd|   } Magnitude of displacement current density
 	\item {\tt Jd.n } Normal displacement current density
 	\item {\tt Jd.t } Tangential displacement current density
 \end{itemize}

--- a/manual/cflowlua.tex
+++ b/manual/cflowlua.tex
@@ -51,7 +51,7 @@ segments and block labels. This function will clear all previously selected
 elements and leave the edit mode in 4 (group)
 
 \item{\tt ci\_selectcircle(x,y,R,editmode)} selects objects within a circle of radius
-R centered at (x,y).  If only x, y, and R paramters are given, the current
+R centered at (x,y).  If only x, y, and R parameters are given, the current
 edit mode is used.  If the editmode parameter is used, 0 denotes nodes, 2
 denotes block labels, 2 denotes segments, 3 denotes arcs, and 4 specifies
 that all entity types are to be selected.
@@ -142,7 +142,7 @@ entries are
 \texttt{"mils"}, \texttt{"meters}, and \texttt{"micrometers"}. Set
 \texttt{problemtype} to \texttt{"planar"} for a 2-D planar problem, or to
 \texttt{"axi"} for an axisymmetric problem. The \texttt{frequency} parameter specifies the frequency
-in Hz at which the analysis ois to be performed. The \texttt{precision} parameter
+in Hz at which the analysis is to be performed. The \texttt{precision} parameter
 dictates the precision required by the solver. For example, entering
 \texttt{1.E-8} requires the RMS of the residual to be less than 10$^{ - 8}$.
 A fourth parameter, representing the depth of the problem in the
@@ -162,7 +162,7 @@ current geometry.
 electrostatics input file upon which Lua commands are to act. If
 more than one electrostatics input file is being edited at a time,
 this command can be used to switch between files so that the
-mutiple files can be operated upon programmatically via Lua. {\tt
+multiple files can be operated upon programmatically via Lua. {\tt
 documentname} should contain the name of the desired document as
 it appears on the window's title bar.
 
@@ -485,7 +485,7 @@ should be set to 1.
 \item{\tt ci\_savedxf("filename")} This function saves geometry information in a dxf file specified by {\tt "filename"}.
 
 \item{\tt ci\_defineouterspace(Zo,Ro,Ri)} defines
-an axisymmetric external region to be used in conjuction with the
+an axisymmetric external region to be used in conjunction with the
 Kelvin Transformation method of modeling unbounded problems.  The
 {\tt Zo} parameter is the z-location of the origin of the outer region,
 the {\tt Ro} parameter is the radius of the outer region, and the {\tt
@@ -605,7 +605,7 @@ are specified, the command is interpreted as a request to plot the requested
 plot type to the screen. If, in addition, the Filename parameter is
 specified, the plot is instead written to disk to the specified file name as
 an extended metafile. If the FileFormat parameter is also, the command is
-instead interpreted as a command to write the data to disk to the specfied
+instead interpreted as a command to write the data to disk to the specified
 file name, rather than display it to make a graphical plot. Valid entries
 for PlotType are:
 
@@ -708,7 +708,7 @@ arcsegment. The \texttt{selectpoint} command has the same
 functionality as the left-button-click contour point selection when
 the program is running in interactive mode.
 
-\item \texttt{co\_clearcontour()} Clear a prevously defined contour
+\item \texttt{co\_clearcontour()} Clear a previously defined contour
 
 \item \texttt{co\_clearblock()} Clear block selection
 \end{itemize}

--- a/manual/eleclua.tex
+++ b/manual/eleclua.tex
@@ -51,7 +51,7 @@ segments and block labels. This function will clear all previously selected
 elements and leave the edit mode in 4 (group)
 
 \item{\tt ei\_selectcircle(x,y,R,editmode)} selects objects within a circle of radius
-R centered at (x,y).  If only x, y, and R paramters are given, the current
+R centered at (x,y).  If only x, y, and R parameters are given, the current
 edit mode is used.  If the editmode parameter is used, 0 denotes nodes, 2
 denotes block labels, 2 denotes segments, 3 denotes arcs, and 4 specifies
 that all entity types are to be selected.
@@ -161,7 +161,7 @@ current geometry.
 electrostatics input file upon which Lua commands are to act. If
 more than one electrostatics input file is being edited at a time,
 this command can be used to switch between files so that the
-mutiple files can be operated upon programmatically via Lua. {\tt
+multiple files can be operated upon programmatically via Lua. {\tt
 documentname} should contain the name of the desired document as
 it appears on the window's title bar.
 
@@ -472,10 +472,10 @@ should be set to 1.
 
 \item{\tt ei\_readdxf("filename")} This function imports a dxf file specified by {\tt "filename"}.
 
-\item{\tt ei\_savedxf("filename")} This function saves geometry informatoin in a dxf file specified by {\tt "filename"}.
+\item{\tt ei\_savedxf("filename")} This function saves geometry information in a dxf file specified by {\tt "filename"}.
 
 \item{\tt ei\_defineouterspace(Zo,Ro,Ri)} defines
-an axisymmetric external region to be used in conjuction with the
+an axisymmetric external region to be used in conjunction with the
 Kelvin Transformation method of modeling unbounded problems.  The
 {\tt Zo} parameter is the z-location of the origin of the outer region,
 the {\tt Ro} parameter is the radius of the outer region, and the {\tt
@@ -581,7 +581,7 @@ are specified, the command is interpreted as a request to plot the requested
 plot type to the screen. If, in addition, the Filename parameter is
 specified, the plot is instead written to disk to the specified file name as
 an extended metafile. If the FileFormat parameter is also, the command is
-instead interpreted as a command to write the data to disk to the specfied
+instead interpreted as a command to write the data to disk to the specified
 file name, rather than display it to make a graphical plot. Valid entries
 for PlotType are:
 
@@ -672,7 +672,7 @@ arcsegment. The \texttt{selectpoint} command has the same
 functionality as the left-button-click contour point selection when
 the program is running in interactive mode.
 
-\item \texttt{eo\_clearcontour()} Clear a prevously defined contour
+\item \texttt{eo\_clearcontour()} Clear a previously defined contour
 
 \item \texttt{eo\_clearblock()} Clear block selection
 \end{itemize}

--- a/manual/heatflow.tex.in
+++ b/manual/heatflow.tex.in
@@ -179,7 +179,7 @@ descriptive name for the material that is being described. Enter it in the
 \texttt{Name} edit box in lieu of {\tt New Material}.
 
 Next, the thermal conductivity for the material needs to be specified. There is a drop
-list on the dialog that allows the user to select either a contant thermal conductivity
+list on the dialog that allows the user to select either a constant thermal conductivity
 ({\em i.e.} independent of temperature), or a thermal conductivity that is prescribed
 as a function of temperature. If conductivity is selected, FEMM allows you
 to specify different conductivities in the vertical and horizontal

--- a/manual/heatlua.tex
+++ b/manual/heatlua.tex
@@ -51,7 +51,7 @@ segments and block labels. This function will clear all previously selected
 elements and leave the edit mode in 4 (group)
 
 \item{\tt hi\_selectcircle(x,y,R,editmode)} selects objects within a circle of radius
-R centered at (x,y).  If only x, y, and R paramters are given, the current
+R centered at (x,y).  If only x, y, and R parameters are given, the current
 edit mode is used.  If the editmode parameter is used, 0 denotes nodes, 2
 denotes block labels, 2 denotes segments, 3 denotes arcs, and 4 specifies
 that all entity types are to be selected.
@@ -164,7 +164,7 @@ current geometry.
 heat flow input file upon which Lua commands are to act. If
 more than one heat flow input file is being edited at a time,
 this command can be used to switch between files so that the
-mutiple files can be operated upon programmatically via Lua. {\tt
+multiple files can be operated upon programmatically via Lua. {\tt
 documentname} should contain the name of the desired document as
 it appears on the window's title bar.
 
@@ -478,7 +478,7 @@ should be set to 1.
 \item{\tt hi\_savedxf("filename")} This function saves geometry information in a dxf file specified by {\tt "filename"}.
 
 \item{\tt hi\_defineouterspace(Zo,Ro,Ri)} defines
-an axisymmetric external region to be used in conjuction with the
+an axisymmetric external region to be used in conjunction with the
 Kelvin Transformation method of modeling unbounded problems.  The
 {\tt Zo} parameter is the z-location of the origin of the outer region,
 the {\tt Ro} parameter is the radius of the outer region, and the {\tt
@@ -580,7 +580,7 @@ are specified, the command is interpreted as a request to plot the requested
 plot type to the screen. If, in addition, the Filename parameter is
 specified, the plot is instead written to disk to the specified file name as
 an extended metafile. If the FileFormat parameter is also, the command is
-instead interpreted as a command to write the data to disk to the specfied
+instead interpreted as a command to write the data to disk to the specified
 file name, rather than display it to make a graphical plot. Valid entries
 for PlotType are:
 
@@ -671,7 +671,7 @@ arcsegment. The \texttt{selectpoint} command has the same
 functionality as the left-button-click contour point selection when
 the program is running in interactive mode.
 
-\item \texttt{ho\_clearcontour()} Clear a prevously defined contour
+\item \texttt{ho\_clearcontour()} Clear a previously defined contour
 
 \item \texttt{ho\_clearblock()} Clear block selection
 \end{itemize}

--- a/manual/magnlua.tex
+++ b/manual/magnlua.tex
@@ -150,7 +150,7 @@ segments and blocklabels. This function will clear all previously selected
 elements and leave the editmode in 4 (group)
 
 \item{\tt mi\_selectcircle(x,y,R,editmode)} selects objects within a circle of radius
-R centered at (x,y).  If only x, y, and R paramters are given, the current
+R centered at (x,y).  If only x, y, and R parameters are given, the current
 edit mode is used.  If the editmode parameter is used, 0 denotes nodes, 2
 denotes block labels, 2 denotes segments, 3 denotes arcs, and 4 specifies
 that all entity types are to be selected.
@@ -250,7 +250,7 @@ current geometry.
 magnetics input file upon which Lua commands are to act. If
 more than one magnetics input file is being edited at a time,
 this command can be used to switch between files so that the
-mutiple files can be operated upon programmatically via Lua. {\tt
+multiple files can be operated upon programmatically via Lua. {\tt
 documentname} should contain the name of the desired document as
 it appears on the window's title bar.
 
@@ -419,7 +419,7 @@ has a flux density of {\tt b} in units of Teslas and a field
 intensity of {\tt h} in units of Amps/Meter.
 
 \item{\tt mi\_clearbhpoints("blockname")} Clears all B-H data points
-associatied with the material specified by {\tt "blockname"}.
+associated with the material specified by {\tt "blockname"}.
 
 \item{\tt mi\_addpointprop("pointpropname",a,j)}
 adds a new point property of name {\tt "pointpropname"} with either
@@ -435,7 +435,7 @@ BdryFormat, ia, oa)} \\ adds a new boundary property with name {\tt
         A1, A2} and {\tt Phi} parameters as required. Set all other
         parameters to zero.
 
-        \item For a ``Small Skin Depth'' type boundary condtion, set the {\tt Mu}
+        \item For a ``Small Skin Depth'' type boundary condition, set the {\tt Mu}
         to the desired relative permeability and {\tt Sig} to the desired
         conductivity in MS/m.  Set {\tt BdryFormat} to 1 and all other
         parameters to zero.
@@ -577,7 +577,7 @@ names, the parameter should be set to 1.
 \item{\tt mi\_readdxf("filename")} This function imports a dxf file specified by {\tt "filename"}.
 \item{\tt mi\_savedxf("filename")} This function saves geometry informationin a dxf file specified by {\tt "filename"}.
 \item{\tt mi\_defineouterspace(Zo,Ro,Ri)} defines
-an axisymmetric external region to be used in conjuction with the
+an axisymmetric external region to be used in conjunction with the
 Kelvin Transformation method of modeling unbounded problems.  The
 {\tt Zo} parameter is the z-location of the origin of the outer region,
 the {\tt Ro} parameter is the radius of the outer region, and the {\tt
@@ -723,7 +723,7 @@ and {\tt NumPoints} are specified, the command is interpreted as a request to pl
 requested plot type to the screen.  If, in addition, the {\tt Filename} parameter is specified,
 the plot is instead written to disk to the specified file name as an extended metafile.
 If the {\tt FileFormat} parameter is also, the command is instead interpreted as a command to
-write the data to disk to the specfied file name, rather than display it to make a
+write the data to disk to the specified file name, rather than display it to make a
 graphical plot.
 Valid entries for {\tt PlotType} are:
 \begin{center}
@@ -859,7 +859,7 @@ selected points lie at the ends of an arcsegment, a contour is
 added that traces along the arcsegment.  The {\tt mo\_selectpoint}
 command has the same functionality as the left-button-click contour
 point selection when the program is running in interactive mode.
-\item{\tt mo\_clearcontour()} Clear a prevously defined contour
+\item{\tt mo\_clearcontour()} Clear a previously defined contour
 \item{\tt mo\_clearblock()} Clear block selection
 \end{itemize}
 

--- a/manual/manual.tex.in
+++ b/manual/manual.tex.in
@@ -190,7 +190,7 @@ Computer-aided analysis and design of electromagnetic devices}
 \cite{Hoole}.  For an advanced treatment, the reader has no
 recourse but to refer to Jackson's {\em Classical electrodynamics}
 \cite{Jackson}.  For thermal problems, the author has found
-White's {\em Heat and mass tranfer} \cite{FrankWhite} and
+White's {\em Heat and mass transfer} \cite{FrankWhite} and
 Haberman's {\em Elementary applied partial differential equations}
 \cite{Haberman} to be useful in understanding the derivation and solution of
 steady-state temperature problems.
@@ -199,7 +199,7 @@ steady-state temperature problems.
 
 FEMM addresses some limiting cases of Maxwell's equations.  The
 magnetics problems addressed are those that can be consided as
-``low frequency problems,'' in which displacment currents can be
+``low frequency problems,'' in which displacement currents can be
 ignored. Displacement currents are typically relevant to magnetics
 problems only at radio frequencies.  In a similar vein, the
 electrostatics solver considers the converse case in which only the
@@ -371,7 +371,7 @@ domain with user-defined sources and boundary conditions.
 \subsection{Heat Flow Problems}
 
 The heat flow problems address by FEMM are essentially steady-state
-heat conduction problems. These probelms are represented by a
+heat conduction problems. These problems are represented by a
 temperature gradient, $G$(analogous to the field intensity, $E$ for
 electrostatic problems), and heat flux density, $F$(analogous to
 electric flux density, $D$, for electrostatic problems).
@@ -497,7 +497,7 @@ At zero frequency, the term associated with electrical permittivity vanishes, le
 \label{quasielectrostatic7}
 - \sigma \nabla^2 V = 0
 \end{equation}
-By simply specifing a zero frequency, this formulation solves DC current flow problems
+By simply specifying a zero frequency, this formulation solves DC current flow problems
 in a consistent fashion.
 
 
@@ -660,7 +660,7 @@ revision 13 standards. Only 2D dxf files can be imported in a
 meaningful way.
 
 To import a dxf file, select \texttt{Import DXF} off of the
-\texttt{File} menu. A dialog will appear after the file is seleted
+\texttt{File} menu. A dialog will appear after the file is selected
 asking for a tolerance. This tolerance is the maximum distance
 between two points at which the program considers two points to be
 the same. The default value is usually sufficient. For some files,
@@ -1414,7 +1414,7 @@ insulation) in this edit box in units of millimeters.
 Associated with the lamination thickness edit box is the {\tt Lam
 fill factor} edit box.  This is the fraction of the core that is
 filled with iron.  For example, if you had a lamination in which
-the iron was 12.8 mils thick, and the insulation bewteen
+the iron was 12.8 mils thick, and the insulation between
 laminations was 1.2 mils thick, the fill factor would be:
 \begin{displaymath}
 \mbox{Fill Factor} = \frac{12.8}{1.2+12.8} = 0.914
@@ -1542,7 +1542,7 @@ grading required in the external region.  This is where the ``External Region'' 
 come in--these are the parameters that the program needs to define the permeabilities of
 elements in the external region for ``unbounded'' axisymmetric problems.
 
-Specifically, there are three parametes that are collected in the dialog that appears when
+Specifically, there are three parameters that are collected in the dialog that appears when
 the user selects the External Region properties.  These are:
 
 \begin{itemize}
@@ -2991,7 +2991,7 @@ Metafile (\texttt{.emf} format), respectively. The clipboard data
 can then be pasted directly into most applications (e.g. Word, MS
 Paint, etc).
 
-L$_{A}$T$_{E}$X afficionados typically find PostScript to be the
+L$_{A}$T$_{E}$X aficionados typically find PostScript to be the
 most useful type of graphics output. FEMM does not support
 postscript output directly, but it is still relatively easy to
 create postcript figures with FEMM. To obtain a postscript version
@@ -3405,7 +3405,7 @@ Since L and W are arbitrarily chosen, the bulk permeability of the
 section is:
 \be \label{ez1} \mu_{ez}= ((1-c) + c \mu_r) \mu_o \ee
 For the solution of nonlinear problems, the derivation of the
-changes to Newton's method to accomodate the bulk lamination model
+changes to Newton's method to accommodate the bulk lamination model
 are greatly simplified if it is assumed that $(1-c) << c
 \mu_r$. In this case, $\mu_{ez}$ can be approximated as:
 \be \label{ez2} \mu_{ez} \approx c \mu_r \mu_o \ee

--- a/mathfemm/usage.nb
+++ b/mathfemm/usage.nb
@@ -42,7 +42,7 @@ MathFEMM can find the FEMM executable:
 <<c:\\progra~1\\femm42\\mathfemm\\mathfemm.m
 3) Run the SetPathToFEMM command to specify the path to the FEMM executable:
 SetPathToFEMM[\"c:\\\\progra~1\\\\femm42\\\\bin\\\\femm.exe\"]
-where you'd replace the above path withe the one to femm.exe in your \
+where you'd replace the above path with the one to femm.exe in your \
 installation.Be sure to use double backslashes in the path specification
 
 USE:To start an MathFEMM session,first load up the MathFEMM package using the \
@@ -109,7 +109,7 @@ with the message \\\"string\\\"\"\>"], "Print",
 
 Cell[BoxData["\<\"Prompt[\\\"string\\\"] displays a pop-up dialog with the \
 message \\\"string\\\" displayed on it with an edit box.  The return value of \
-the funciton is the contents of the edit box.\"\>"], "Print",
+the function is the contents of the edit box.\"\>"], "Print",
  CellTags->"Info3347223940-7924268"],
 
 Cell[BoxData["\<\"MLPut[\\\"string\\\"] sends \\\"string\\\" to FEMM's Lua \
@@ -437,7 +437,7 @@ segments and arc segments.\"\>"], "Print",
  CellTags->"Info3347223941-8020983"],
 
 Cell[BoxData["\<\"EIDefineOuterSpace[Zo,Ro,Ri] defines an axisymmetric \
-external region to be used in conjuction with the Kelvin Transformation \
+external region to be used in conjunction with the Kelvin Transformation \
 method of modeling unbounded problems.  The Zo parameter is the z-location of \
 the origin of the outer region, the Ro parameter is the radius of the outer \
 region, and the Ri parameter is the radius of the inner region (i.e. the \
@@ -662,7 +662,7 @@ parameter.\"\>"], "Print",
 Cell[BoxData["\<\"EISetFocus[\\\"documentname\\\"] switches the \
 electrostatics input file upon which scripting commands are to act. If more \
 than one electrostatics input file is being edited at a time, this command \
-can be used to switch between files so that the mutiple files can be operated \
+can be used to switch between files so that the multiple files can be operated \
 upon programmatically . \\\"documentname\\\" should contain the name of the \
 desired document as it appears on the window\[CloseCurlyQuote]s title \
 bar.\"\>"], "Print",
@@ -953,7 +953,7 @@ segments and arc segments.\"\>"], "Print",
  CellTags->"Info3347223941-2948475"],
 
 Cell[BoxData["\<\"HIDefineOuterSpace[Zo,Ro,Ri] defines an axisymmetric \
-external region to be used in conjuction with the Kelvin Transformation \
+external region to be used in conjunction with the Kelvin Transformation \
 method of modeling unbounded problems.  The Zo parameter is the z-location of \
 the origin of the outer region, the Ro parameter is the radius of the outer \
 region, and the Ri parameter is the radius of the inner region (i.e. the \
@@ -1178,7 +1178,7 @@ parameter.\"\>"], "Print",
 Cell[BoxData["\<\"HISetFocus[\\\"documentname\\\"] switches the heat flow \
 input file upon which scripting commands are to act. If more than one heat \
 flow input file is being edited at a time, this command can be used to switch \
-between files so that the mutiple files can be operated upon programmatically \
+between files so that the multiple files can be operated upon programmatically \
 . \\\"documentname\\\" should contain the name of the desired document as it \
 appears on the window\[CloseCurlyQuote]s title bar.\"\>"], "Print",
  CellTags->"Info3347223941-7628927"]
@@ -1470,7 +1470,7 @@ segments and arc segments.\"\>"], "Print",
  CellTags->"Info3347223942-3777925"],
 
 Cell[BoxData["\<\"CIDefineOuterSpace[Zo,Ro,Ri] defines an axisymmetric \
-external region to be used in conjuction with the Kelvin Transformation \
+external region to be used in conjunction with the Kelvin Transformation \
 method of modeling unbounded problems.  The Zo parameter is the z-location of \
 the origin of the outer region, the Ro parameter is the radius of the outer \
 region, and the Ri parameter is the radius of the inner region (i.e. the \
@@ -1696,7 +1696,7 @@ parameter.\"\>"], "Print",
 Cell[BoxData["\<\"CISetFocus[\\\"documentname\\\"] switches the current input \
 file upon which scripting commands are to act. If more than one current input \
 file is being edited at a time, this command can be used to switch between \
-files so that the mutiple files can be operated upon programmatically . \
+files so that the multiple files can be operated upon programmatically . \
 \\\"documentname\\\" should contain the name of the desired document as it \
 appears on the window\[CloseCurlyQuote]s title bar.\"\>"], "Print",
  CellTags->"Info3347223942-2698508"]
@@ -1722,7 +1722,7 @@ Cell[BoxData["\<\"MIAddBoundProp[\\\"propname\\\",A0,A1,A2,Phi,Mu,Sig,c0,c1,\
 BdryFormat] adds a new boundary property with name \\\"propname\\\" \\n \
 \[Dash] For a \\\"Prescribed A\\\" type boundary condition, set the A0, A1, \
 A2  and Phi parameters as required. Set all other parameters to zero.\\n \
-\[Dash] For a \\\"Small Skin Depth\\\" type boundary condtion, set the Mu to \
+\[Dash] For a \\\"Small Skin Depth\\\" type boundary condition, set the Mu to \
 the desired relative permeability and Sig to the desired conductivity in \
 MS/m. Set BdryFormat to 1 and all other parameters to zero. \\n \[Dash] To \
 obtain a \\\"Mixed\\\" type boundary condition, set C1 and C0 as required and \
@@ -2027,7 +2027,7 @@ segments and arc segments.\"\>"], "Print",
  CellTags->"Info3347223942-3630767"],
 
 Cell[BoxData["\<\"MIDefineOuterSpace[Zo,Ro,Ri] defines an axisymmetric \
-external region to be used in conjuction with the Kelvin Transformation \
+external region to be used in conjunction with the Kelvin Transformation \
 method of modeling unbounded problems.  The Zo parameter is the z-location of \
 the origin of the outer region, the Ro parameter is the radius of the outer \
 region, and the Ri parameter is the radius of the inner region (i.e. the \
@@ -2253,7 +2253,7 @@ parameter.\"\>"], "Print",
 Cell[BoxData["\<\"MISetFocus[\\\"documentname\\\"] switches the \
 electrostatics input file upon which scripting commands are to act. If more \
 than one electrostatics input file is being edited at a time, this command \
-can be used to switch between files so that the mutiple files can be operated \
+can be used to switch between files so that the multiple files can be operated \
 upon programmatically . \\\"documentname\\\" should contain the name of the \
 desired document as it appears on the window\[CloseCurlyQuote]s title \
 bar.\"\>"], "Print",
@@ -2338,7 +2338,7 @@ interpreted as a request to plot the requested plot type to the screen. If, \
 in addition, the Filename parameter is specified, the plot is instead written \
 to disk to the specified file name as an extended metafile. If the FileFormat \
 parameter is also, the command is instead interpreted as a command to write \
-the data to disk to the specfied file name, rather than display it to make a \
+the data to disk to the specified file name, rather than display it to make a \
 graphical plot. Valid entries for PlotType are: \\n 0 - V (Voltage)\\n 1 - \
 |D| (Magnitude of flux density)\\n 2 - D . n (Normal flux density)\\n 3 - D . \
 t (Tangential flux density)\\n 4 - |E| (Magnitude of field intensity)\\n 5 - \
@@ -2627,7 +2627,7 @@ interpreted as a request to plot the requested plot type to the screen. If, \
 in addition, the Filename parameter is specified, the plot is instead written \
 to disk to the specified file name as an extended metafile. If the FileFormat \
 parameter is also, the command is instead interpreted as a command to write \
-the data to disk to the specfied file name, rather than display it to make a \
+the data to disk to the specified file name, rather than display it to make a \
 graphical plot. Valid entries for PlotType are: \\n 0 - T (temperature)\\n 1 \
 - |F| (Magnitude of heat flux density)\\n 2 - F . n (Normal heat flux \
 density)\\n 3 - F . t (Tangential heat flux density)\\n 4 - |G| (Magnitude of \
@@ -2918,7 +2918,7 @@ interpreted as a request to plot the requested plot type to the screen. If, \
 in addition, the Filename parameter is specified, the plot is instead written \
 to disk to the specified file name as an extended metafile. If the FileFormat \
 parameter is also, the command is instead interpreted as a command to write \
-the data to disk to the specfied file name, rather than display it to make a \
+the data to disk to the specified file name, rather than display it to make a \
 graphical plot. Valid entries for PlotType are: \\n  0   V (Voltage) \\n  1   \
 |J| (Magnitude of current density) \\n  2   J.n (Normal current density) \\n  \
 3   J.t (Tangential current density) \\n  4   |E (Magnitude of field \
@@ -3227,7 +3227,7 @@ interpreted as a request to plot the requested plot type to the screen. If, \
 in addition, the Filename parameter is specified, the plot is instead written \
 to disk to the specified file name as an extended metafile. If the FileFormat \
 parameter is also, the command is instead interpreted as a command to write \
-the data to disk to the specfied file name, rather than display it to make a \
+the data to disk to the specified file name, rather than display it to make a \
 graphical plot. Valid entries for PlotType are: \\n 0 - Potential \\n 1 - |B| \
 \\n 2 B\[CenterDot]n \\n 3 - B\[CenterDot]t \\n 4 - |H| \\n 5 - H \
 \[CenterDot]n \\n 6 - H \[CenterDot]t \\n 7 - Jeddy \\n 8 - \
@@ -3268,7 +3268,7 @@ hysteresis\\n ff - Winding fill factor\"\>"], "Print",
 
 Cell[BoxData["\<\"MOGetA[x,y] returns the vector potential, A, for 2D planar \
 problems, and it returns flux, 2*Pi*r*A, for axisymmetric problems.  The \
-return value is possbly complex-valued. An equivalent form is:\\n \
+return value is possibly complex-valued. An equivalent form is:\\n \
 MOGetA[{x,y}]\"\>"], "Print",
  CellTags->"Info3347223944-4082389"],
 

--- a/triangle/triangle.c
+++ b/triangle/triangle.c
@@ -334,7 +334,7 @@
 
 #define PI 3.141592653589793238462643383279502884197169399375105820974944592308
 
-/* Another fave.                                                             */
+/* Another save.                                                             */
 
 #define SQUAREROOTTWO 1.4142135623730950488016887242096980785696718753769480732
 
@@ -891,7 +891,7 @@ struct behavior {
 /*  org:  Origin          dest:  Destination          apex:  Apex            */
 /*  org(abc) -> a         dest(abc) -> b              apex(abc) -> c         */
 /*                                                                           */
-/*  bond:  Bond two triangles together at the resepective handles.           */
+/*  bond:  Bond two triangles together at the respective handles.           */
 /*  bond(abc, bad)                                                           */
 /*                                                                           */
 /*                                                                           */


### PR DESCRIPTION
Found via `codespell -q 3 -L alo,ans,bu,clen,inout,parms,ro,som`